### PR TITLE
ci: Switch arduino-lint to "update" mode

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,7 +23,7 @@ jobs:
       - name: arduino-lint
         uses: arduino/arduino-lint-action@v1
         with:
-          library-manager: submit # TODO: swith to "update" when approved by the Arduino Team
+          library-manager: update
           compliance: strict
 
       - name: Code format


### PR DESCRIPTION
Now referenced as part of Arduino libraries: https://www.arduino.cc/reference/en/libraries/epson_pnl_ce02/